### PR TITLE
Add basic audio playback

### DIFF
--- a/components/recording/RecordingControls.tsx
+++ b/components/recording/RecordingControls.tsx
@@ -8,6 +8,7 @@ export default function RecordingControls() {
     stopRecording,
     playLastRecording,
     lastRecordingUri,
+    recordingDuration,
   } = useAudioRecorder();
 
   return (
@@ -16,9 +17,17 @@ export default function RecordingControls() {
         title={recording ? 'Stop Recording' : 'Start Recording'}
         onPress={recording ? stopRecording : startRecording}
       />
-      {recording && <Text>Recording...</Text>}
+      {recording && (
+        <View style={{ alignItems: 'center' }}>
+          <Text>Recording...</Text>
+          <Text>Duration: {Math.floor(recordingDuration / 1000)}s</Text>
+        </View>
+      )}
       {!recording && lastRecordingUri && (
-        <Button title="Play Last Recording" onPress={playLastRecording} />
+        <View style={{ alignItems: 'center' }}>
+          <Text>Recording saved at: {lastRecordingUri}</Text>
+          <Button title="Play Last Recording" onPress={playLastRecording} />
+        </View>
       )}
     </View>
   );

--- a/hooks/useAudioRecorder.ts
+++ b/hooks/useAudioRecorder.ts
@@ -5,6 +5,7 @@ import notifee from '@notifee/react-native';
 export default function useAudioRecorder() {
   const [recording, setRecording] = useState<Audio.Recording | null>(null);
   const [lastRecordingUri, setLastRecordingUri] = useState<string | null>(null);
+  const [recordingDuration, setRecordingDuration] = useState<number>(0);
 
   const startRecording = async () => {
     try {
@@ -24,6 +25,12 @@ export default function useAudioRecorder() {
         Audio.RecordingOptionsPresets.HIGH_QUALITY
       );
 
+      recording.setOnRecordingStatusUpdate((status) => {
+        if (status.isRecording) {
+          setRecordingDuration(status.durationMillis);
+        }
+      });
+
       const channelId = await notifee.createChannel({
         id: 'recording',
         name: 'Recording',
@@ -39,6 +46,7 @@ export default function useAudioRecorder() {
       });
 
       setRecording(recording);
+      setRecordingDuration(0);
     } catch (err) {
       console.error('Failed to start recording', err);
     }
@@ -48,8 +56,11 @@ export default function useAudioRecorder() {
     try {
       if (!recording) return;
       await recording.stopAndUnloadAsync();
-      setLastRecordingUri(recording.getURI() ?? null);
+      const uri = recording.getURI();
+      setLastRecordingUri(uri ?? null);
       setRecording(null);
+      setRecordingDuration(0);
+      console.log('Recording stopped. URI:', uri);
       await notifee.stopForegroundService();
     } catch (err) {
       console.error('Failed to stop recording', err);
@@ -58,7 +69,11 @@ export default function useAudioRecorder() {
 
   const playLastRecording = async () => {
     try {
-      if (!lastRecordingUri) return;
+      if (!lastRecordingUri) {
+        console.log('No recording URI found');
+        return;
+      }
+      console.log('Playing recording from URI:', lastRecordingUri);
       const { sound } = await Audio.Sound.createAsync({ uri: lastRecordingUri });
       sound.setOnPlaybackStatusUpdate((status) => {
         if (status.isLoaded && status.didJustFinish) {
@@ -66,10 +81,18 @@ export default function useAudioRecorder() {
         }
       });
       await sound.playAsync();
+      console.log('Playback started');
     } catch (err) {
       console.error('Failed to play recording', err);
     }
   };
 
-  return { recording, startRecording, stopRecording, playLastRecording, lastRecordingUri };
+  return { 
+    recording, 
+    startRecording, 
+    stopRecording, 
+    playLastRecording, 
+    lastRecordingUri,
+    recordingDuration
+  };
 }


### PR DESCRIPTION
## Summary
- store recorded URI in `useAudioRecorder`
- add function to play last recording
- expose playback via RecordingControls UI

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687886a1348c833196a63ae76769e5db