### PR TITLE
Implement conversation history screen

### DIFF
--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -1,9 +1,36 @@
-import { View, Text } from 'react-native';
+import { FlatList, View, Text, ActivityIndicator } from "react-native";
+import useConversations from "@/hooks/useConversations";
+import ConversationItem from "@/components/history/ConversationItem";
 
 export default function HistoryScreen() {
+  const { data, loading, error } = useConversations();
+
+  if (loading) {
+    return (
+      <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+        <Text>{error}</Text>
+      </View>
+    );
+  }
+
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text>History Screen</Text>
-    </View>
+    <FlatList
+      data={data || []}
+      keyExtractor={(item) => item.id}
+      renderItem={({ item }) => <ConversationItem conversation={item} />}
+      ListEmptyComponent={
+        <View style={{ alignItems: "center", marginTop: 40 }}>
+          <Text>No conversations yet.</Text>
+        </View>
+      }
+    />
   );
 }

--- a/components/history/ConversationItem.tsx
+++ b/components/history/ConversationItem.tsx
@@ -1,0 +1,47 @@
+import { ConversationDTO } from "@/types/conversation";
+import { View, Text, StyleSheet } from "react-native";
+
+interface Props {
+  conversation: ConversationDTO;
+}
+
+export default function ConversationItem({ conversation }: Props) {
+  const date = new Date(conversation.created_at);
+  return (
+    <View style={styles.container}>
+      <View style={styles.textContainer}>
+        <Text style={styles.title}>{conversation.file_name}</Text>
+        <Text style={styles.date}>{date.toLocaleString()}</Text>
+      </View>
+      <Text style={styles.status}>{conversation.status}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderBottomColor: "#ccc",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    alignItems: "center",
+  },
+  textContainer: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  date: {
+    fontSize: 12,
+    color: "#666",
+  },
+  status: {
+    marginLeft: 8,
+    fontSize: 12,
+    color: "#666",
+  },
+});

--- a/hooks/useConversations.ts
+++ b/hooks/useConversations.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { usePrivy } from "@privy-io/expo";
+import { fetchConversations } from "@/services/api";
+import { ConversationDTO } from "@/types/conversation";
+
+export default function useConversations() {
+  const { user, getAccessToken } = usePrivy();
+  const [data, setData] = useState<ConversationDTO[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    let canceled = false;
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const token = (await getAccessToken()) || "";
+        const conversations = await fetchConversations(user.id, token);
+        if (!canceled) setData(conversations);
+      } catch (err) {
+        if (!canceled) {
+          const msg = err instanceof Error ? err.message : String(err);
+          setError(msg);
+        }
+      } finally {
+        if (!canceled) setLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      canceled = true;
+    };
+  }, [user]);
+
+  return { data, loading, error };
+}

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,3 +1,4 @@
+import { ConversationDTO } from "@/types/conversation";
 export const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || "https://otomvp-api-78nm.onrender.com";
 
 export interface UploadResponse {
@@ -59,4 +60,20 @@ export async function uploadAudio(
     xhr.setRequestHeader("Oto-User-Id", userId);
     xhr.send(formData);
   });
+}
+
+export async function fetchConversations(
+  userId: string,
+  token: string
+): Promise<ConversationDTO[]> {
+  const res = await fetch(`${API_BASE_URL}/conversation/list`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Oto-User-Id': userId,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return (await res.json()) as ConversationDTO[];
 }

--- a/types/conversation.ts
+++ b/types/conversation.ts
@@ -1,0 +1,21 @@
+export type ConversationStatus =
+  | 'not_started'
+  | 'processing'
+  | 'completed'
+  | 'failed';
+
+export interface ConversationDTO {
+  id: string;
+  created_at: string;
+  updated_at: string;
+  status: ConversationStatus;
+  file_name: string;
+  mime_type: string;
+  available_duration?: string;
+  language?: string;
+  situation?: string;
+  place?: string;
+  time?: string;
+  location?: string;
+  points?: number;
+}


### PR DESCRIPTION
## Summary
- define `ConversationDTO` and fetch API helpers
- list uploaded conversations in the History tab
- add reusable `ConversationItem` component
- provide `useConversations` hook to load data

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68789acdd5ac8331b0395d350b2b041c