### PR TITLE
Implement native profile screen

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,13 +1,36 @@
-import { View, Text, Button } from 'react-native';
-import { usePrivy } from '@privy-io/expo';
+import { ScrollView, View, ActivityIndicator } from 'react-native';
+import useUserProfile from '@/hooks/useUserProfile';
+import usePointBalance from '@/hooks/usePointBalance';
+import ProfileForm from '@/components/profile/ProfileForm';
+import EarningsPanel from '@/components/profile/EarningsPanel';
+import AccountActions from '@/components/profile/AccountActions';
 
 export default function ProfileScreen() {
-  const { user, logout } = usePrivy();
-  if (!user) return null;
+  const {
+    data: profile,
+    loading: loadingProfile,
+    save,
+  } = useUserProfile();
+  const {
+    data: balance,
+    loading: loadingPoint,
+  } = usePointBalance();
+
+  const loading = loadingProfile || loadingPoint;
+
+  if (loading && !profile && !balance) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" color="#007AFF" />
+      </View>
+    );
+  }
+
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: 10 }}>
-      <Text>Logged in as {user.id}</Text>
-      <Button title="Logout" onPress={logout} />
-    </View>
+    <ScrollView contentContainerStyle={{ padding: 16 }}>
+      <ProfileForm profile={profile} loading={loadingProfile} onSave={save} />
+      <EarningsPanel balance={balance} loading={loadingPoint} />
+      <AccountActions />
+    </ScrollView>
   );
 }

--- a/components/profile/AccountActions.tsx
+++ b/components/profile/AccountActions.tsx
@@ -1,0 +1,20 @@
+import { View, Button, StyleSheet } from 'react-native';
+import { usePrivy } from '@privy-io/expo';
+
+export default function AccountActions() {
+  const { logout } = usePrivy();
+
+  return (
+    <View style={styles.footer}>
+      <Button title="ログアウト" onPress={logout} />
+      {/* TODO: account deletion flow */}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  footer: {
+    marginTop: 16,
+    gap: 8,
+  },
+});

--- a/components/profile/EarningsPanel.tsx
+++ b/components/profile/EarningsPanel.tsx
@@ -1,0 +1,36 @@
+import { View, Text, StyleSheet } from 'react-native';
+import { PointBalanceResponse } from '@/types/point';
+
+interface Props {
+  balance: PointBalanceResponse | null;
+  loading: boolean;
+}
+
+export default function EarningsPanel({ balance, loading }: Props) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.balance}>
+        {loading ? '--' : `${balance?.points ?? '--'} pts`}
+      </Text>
+      <Text style={styles.caption}>ご利用可能ポイント</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#fff',
+    padding: 16,
+    alignItems: 'center',
+    marginVertical: 8,
+  },
+  balance: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: '#333',
+  },
+  caption: {
+    fontSize: 12,
+    color: '#666',
+  },
+});

--- a/components/profile/ProfileForm.tsx
+++ b/components/profile/ProfileForm.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { UserProfileResponse, UserUpdateRequest } from '@/types/user';
+
+interface Props {
+  profile: UserProfileResponse | null;
+  loading: boolean;
+  onSave: (data: UserUpdateRequest) => void;
+}
+
+export default function ProfileForm({ profile, loading, onSave }: Props) {
+  const [form, setForm] = useState<UserUpdateRequest>({});
+
+  const handleChange = (field: keyof UserUpdateRequest, value: string) => {
+    setForm((f) => ({ ...f, [field]: value }));
+  };
+
+  const handleNumberChange = (field: keyof UserUpdateRequest, value: string) => {
+    const n = parseInt(value, 10);
+    handleChange(field, isNaN(n) ? value : n as any);
+  };
+
+  const handleSave = () => {
+    onSave({ ...profile, ...form });
+  };
+
+  if (!profile) {
+    return (
+      <View style={styles.card}>
+        <Text style={styles.error}>プロフィール取得失敗</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.label}>名前</Text>
+      <TextInput
+        style={styles.input}
+        value={form.name ?? profile.name ?? ''}
+        onChangeText={(v) => handleChange('name', v)}
+        editable={!loading}
+      />
+      <Text style={styles.label}>年齢</Text>
+      <TextInput
+        style={styles.input}
+        keyboardType="number-pad"
+        value={(form.age ?? profile.age ?? '').toString()}
+        onChangeText={(v) => handleNumberChange('age', v)}
+        editable={!loading}
+      />
+      <Text style={styles.label}>国籍</Text>
+      <TextInput
+        style={styles.input}
+        value={form.nationality ?? profile.nationality ?? ''}
+        onChangeText={(v) => handleChange('nationality', v)}
+        editable={!loading}
+      />
+      <Text style={styles.label}>第一言語</Text>
+      <TextInput
+        style={styles.input}
+        value={form.first_language ?? profile.first_language ?? ''}
+        onChangeText={(v) => handleChange('first_language', v)}
+        editable={!loading}
+      />
+      <Text style={styles.label}>第二言語(カンマ区切り)</Text>
+      <TextInput
+        style={styles.input}
+        value={form.second_languages ?? profile.second_languages ?? ''}
+        onChangeText={(v) => handleChange('second_languages', v)}
+        editable={!loading}
+      />
+      <Text style={styles.label}>興味・関心(カンマ区切り)</Text>
+      <TextInput
+        style={styles.input}
+        value={form.interests ?? profile.interests ?? ''}
+        onChangeText={(v) => handleChange('interests', v)}
+        editable={!loading}
+      />
+      <Text style={styles.label}>好みのトピック(カンマ区切り)</Text>
+      <TextInput
+        style={styles.input}
+        value={form.preferred_topics ?? profile.preferred_topics ?? ''}
+        onChangeText={(v) => handleChange('preferred_topics', v)}
+        editable={!loading}
+      />
+      <Button title={loading ? '保存中...' : '保存'} onPress={handleSave} disabled={loading} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#fff',
+    padding: 16,
+    marginVertical: 8,
+  },
+  label: {
+    fontSize: 14,
+    marginTop: 8,
+    marginBottom: 4,
+  },
+  input: {
+    borderColor: '#ccc',
+    borderWidth: 1,
+    borderRadius: 4,
+    padding: 8,
+    fontSize: 14,
+  },
+  error: {
+    color: 'red',
+    textAlign: 'center',
+  },
+});

--- a/hooks/usePointBalance.ts
+++ b/hooks/usePointBalance.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { usePrivy } from '@privy-io/expo';
+import { fetchPointBalance } from '@/services/api';
+import { PointBalanceResponse } from '@/types/point';
+
+export default function usePointBalance() {
+  const { user, getAccessToken } = usePrivy();
+  const [data, setData] = useState<PointBalanceResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    let canceled = false;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const token = (await getAccessToken()) || '';
+        const res = await fetchPointBalance(user.id, token);
+        if (!canceled) setData(res);
+      } catch (err) {
+        if (!canceled) {
+          const msg = err instanceof Error ? err.message : String(err);
+          setError(msg);
+        }
+      } finally {
+        if (!canceled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      canceled = true;
+    };
+  }, [user]);
+
+  return { data, loading, error };
+}

--- a/hooks/useUserProfile.ts
+++ b/hooks/useUserProfile.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { usePrivy } from '@privy-io/expo';
+import { fetchUser, updateUser } from '@/services/api';
+import { UserProfileResponse, UserUpdateRequest } from '@/types/user';
+
+export default function useUserProfile() {
+  const { user, getAccessToken } = usePrivy();
+  const [data, setData] = useState<UserProfileResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    if (!user) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const token = (await getAccessToken()) || '';
+      const res = await fetchUser(user.id, token);
+      setData(res);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const save = async (update: UserUpdateRequest) => {
+    if (!user) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const token = (await getAccessToken()) || '';
+      const res = await updateUser(user.id, token, update);
+      setData(res);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id]);
+
+  return { data, loading, error, reload: load, save };
+}

--- a/services/api.ts
+++ b/services/api.ts
@@ -168,3 +168,58 @@ export async function fetchMicrotrends(): Promise<MicrotrendListResponse> {
   }
   return (await res.json()) as MicrotrendListResponse;
 }
+
+import { UserProfileResponse, UserUpdateRequest } from '@/types/user';
+import { PointBalanceResponse } from '@/types/point';
+
+export async function fetchUser(
+  userId: string,
+  token: string
+): Promise<UserProfileResponse> {
+  const res = await fetch(`${API_BASE_URL}/user/get`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Oto-User-Id': userId,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return (await res.json()) as UserProfileResponse;
+}
+
+export async function updateUser(
+  userId: string,
+  token: string,
+  data: UserUpdateRequest
+): Promise<UserProfileResponse> {
+  const res = await fetch(`${API_BASE_URL}/user/update`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      'Oto-User-Id': userId,
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return (await res.json()) as UserProfileResponse;
+}
+
+export async function fetchPointBalance(
+  userId: string,
+  token: string
+): Promise<PointBalanceResponse> {
+  const res = await fetch(`${API_BASE_URL}/point/get`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Oto-User-Id': userId,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return (await res.json()) as PointBalanceResponse;
+}

--- a/types/point.ts
+++ b/types/point.ts
@@ -1,0 +1,4 @@
+export interface PointBalanceResponse {
+  id: string;
+  points: number;
+}

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,0 +1,12 @@
+export interface UserProfileResponse {
+  id: string;
+  name: string | null;
+  age: number | null;
+  nationality: string | null;
+  first_language: string | null;
+  second_languages: string | null;
+  interests: string | null;
+  preferred_topics: string | null;
+}
+
+export interface UserUpdateRequest extends Partial<UserProfileResponse> {}


### PR DESCRIPTION
## Summary
- add types for user profile and point balance
- extend API client with profile and point calls
- add hooks to fetch and update user profile and point data
- implement profile form, earnings panel and account actions components
- build Profile tab screen with data loading, editing and logout

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687ca5a50a1083319970d58fb2321b8f