### PR TITLE
UI polish and keyboard fix

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,4 +1,4 @@
-import { View, Text, ActivityIndicator, ScrollView } from 'react-native';
+import { View, Text, ActivityIndicator, ScrollView, KeyboardAvoidingView, Platform } from 'react-native';
 import { usePrivy } from '@privy-io/expo';
 import useUserProfile from '@/hooks/useUserProfile';
 import usePointBalance from '@/hooks/usePointBalance';
@@ -34,10 +34,16 @@ export default function ProfileScreen() {
   };
 
   return (
-    <ScrollView style={{ flex: 1 }}>
-      <ProfileForm profile={profile} onSave={handleSave} loading={loadingProfile} />
-      <EarningsPanel balance={balance} />
-      <AccountActions />
-    </ScrollView>
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={80}
+    >
+      <ScrollView style={{ flex: 1 }} keyboardShouldPersistTaps="handled">
+        <ProfileForm profile={profile} onSave={handleSave} loading={loadingProfile} />
+        <EarningsPanel balance={balance} />
+        <AccountActions />
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }

--- a/components/profile/AccountActions.tsx
+++ b/components/profile/AccountActions.tsx
@@ -4,14 +4,9 @@ import { usePrivy } from '@privy-io/expo';
 export default function AccountActions() {
   const { logout } = usePrivy();
 
-  const handleDelete = () => {
-    // TODO: implement account deletion flow
-  };
-
   return (
     <View style={styles.container}>
       <Button title="ログアウト" onPress={logout} />
-      <Button title="アカウント削除" onPress={handleDelete} color="#d9534f" />
     </View>
   );
 }

--- a/components/profile/EarningsPanel.tsx
+++ b/components/profile/EarningsPanel.tsx
@@ -9,7 +9,7 @@ export default function EarningsPanel({ balance }: Props) {
   return (
     <View style={styles.container}>
       <Text style={styles.balance}>{balance ? `${balance.points} pts` : '-- pts'}</Text>
-      <Text style={styles.caption}>ご利用可能ポイント</Text>
+      <Text style={styles.caption}>Earning</Text>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- remove the unused account deletion button
- rename balance caption to **Earning**
- add KeyboardAvoidingView around the profile form

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687ccc9161f083318ee2c09cff724f99